### PR TITLE
Rm sourcing of useprod

### DIFF
--- a/scripts/downsample.sh
+++ b/scripts/downsample.sh
@@ -3,10 +3,9 @@
 # exit on errr
 set -e
 
-#activate production conda env
-shopt -s expand_aliases
-source ${HOME}/.bashrc
-useprod
+log() {
+    >&2 echo $*
+}
 
 VERSION=1.5.0
 log VERSION $VERSION


### PR DESCRIPTION
This PR removes the soucing of bashrc and the activating of useprod right within the script. Instead, the scripts should use the environment sourced in the current shell.

For testing, see: https://github.com/Clinical-Genomics/servers/pull/262